### PR TITLE
Relax rules for Argentina to allow mobile SMS

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ var iso3166_data = [
 	{alpha2: "AD", alpha3: "AND", country_code: "376", country_name: "Andorra", mobile_begin_with: ["3", "4", "6"], phone_number_lengths: [6]},
 	//{alpha2: "AN", alpha3: "ANT", country_code: "599", country_name: "Netherlands Antilles", mobile_begin_with: [], phone_number_lengths: []},
 	{alpha2: "AE", alpha3: "ARE", country_code: "971", country_name: "United Arab Emirates", mobile_begin_with: ["5"], phone_number_lengths: [9]},
-	{alpha2: "AR", alpha3: "ARG", country_code: "54", country_name: "Argentina", mobile_begin_with: ["9"], phone_number_lengths: [10]},
+	{alpha2: "AR", alpha3: "ARG", country_code: "54", country_name: "Argentina", mobile_begin_with: [], phone_number_lengths: [6, 7, 8, 9]},
 	{alpha2: "AM", alpha3: "ARM", country_code: "374", country_name: "Armenia", mobile_begin_with: ["5", "7", "9"], phone_number_lengths: [8]},
 	{alpha2: "AS", alpha3: "ASM", country_code: "1", country_name: "American Samoa", mobile_begin_with: ["733", "258"], phone_number_lengths: [7]},
 	//{alpha2: "AQ", alpha3: "ATA", country_code: "672", country_name: "Antarctica", mobile_begin_with: [], phone_number_lengths: []},


### PR DESCRIPTION
 (which does not support the leading 9) and to allow different lengths of phone number.  Fixes #18 .  See also http://en.wikipedia.org/wiki/Telephone_numbers_in_Argentina#Inbound_SMS