### PR TITLE
Add additional mobile prefixes for Denmark

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -100,7 +100,7 @@ var iso3166_data = [
 	{alpha2: "DE", alpha3: "DEU", country_code: "49", country_name: "Germany", mobile_begin_with: ["15", "16", "17"], phone_number_lengths: [10, 11]},
 	{alpha2: "DJ", alpha3: "DJI", country_code: "253", country_name: "Djibouti", mobile_begin_with: ["77"], phone_number_lengths: [8]},
 	{alpha2: "DM", alpha3: "DMA", country_code: "1", country_name: "Dominica", mobile_begin_with: [], phone_number_lengths: [7]},
-	{alpha2: "DK", alpha3: "DNK", country_code: "45", country_name: "Denmark", mobile_begin_with: ["20", "31", "40", "42", "50", "53", "60", "61", "71", "81", "91", "93"], phone_number_lengths: [8]},
+	{alpha2: "DK", alpha3: "DNK", country_code: "45", country_name: "Denmark", mobile_begin_with: ["2", "30", "31", "40", "41", "42", "50", "51", "52", "53", "60", "61", "71", "81", "91", "92", "93"], phone_number_lengths: [8]},
 	{alpha2: "DO", alpha3: "DOM", country_code: "1", country_name: "Dominican Republic", mobile_begin_with: ["809", "829", "849"], phone_number_lengths: [10]},
 	{alpha2: "DZ", alpha3: "DZA", country_code: "213", country_name: "Algeria", mobile_begin_with: ["5", "6", "7"], phone_number_lengths: [9]},
 	{alpha2: "EC", alpha3: "ECU", country_code: "593", country_name: "Ecuador", mobile_begin_with: ["9"], phone_number_lengths: [9]},


### PR DESCRIPTION
Fixes #22 by adding additional mobile prefixes for Denmark.  See #22 for details.